### PR TITLE
Make the botostubs package PEP 561 compatible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY main.py pythonic.py ./
 COPY setup.py README.md release.sh botostubs/
 
 RUN mkdir botostubs/botostubs
+RUN touch botostubs/botostubs/py.typed
 RUN export AWS_ACCESS_KEY_ID=FAKE AWS_SECRET_ACCESS_KEY=FAKE && time python main.py > botostubs/botostubs/__init__.py
 
 WORKDIR /app/botostubs

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -14,5 +14,6 @@ phases:
       - pip install --upgrade pytest boto3 setuptools wheel twine
       - mkdir -p botostubs/botostubs
       - cp setup.py README.md release.sh botostubs/
+      - touch botostubs/botostubs/py.typed
       - export AWS_ACCESS_KEY_ID=FAKE AWS_SECRET_ACCESS_KEY=FAKE && python main.py > botostubs/botostubs/__init__.py
       - cd botostubs && ./release.sh

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/jeshan/botostubs",
     packages=setuptools.find_packages(),
+    package_data={"botostubs": ["py.typed"]},
+    zip_safe=False,
     license='BSD-2-Clause',
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Without this, tools like mypy won't work correctly. See https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages.